### PR TITLE
Fix image building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY --chown=redash client /frontend/client
 COPY --chown=redash webpack.config.js /frontend/
 RUN if [ "x$skip_frontend_build" = "x" ] ; then yarn build; else mkdir -p /frontend/client/dist && touch /frontend/client/dist/multi_org.html && touch /frontend/client/dist/index.html; fi
 
-FROM python:3.7-slim-buster
+FROM python:3.7-slim-bookworm
 
 EXPOSE 5000
 
@@ -84,10 +84,6 @@ WORKDIR /app
 
 # Disable PIP Cache and Version Check
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
-ENV PIP_NO_CACHE_DIR=1
-
-# rollback pip version to avoid legacy resolver problem
-RUN pip install pip==20.2.4;
 
 # We first copy only the requirements file, to avoid rebuilding on every file change.
 COPY requirements_all_ds.txt ./

--- a/Dockerfile.ecs
+++ b/Dockerfile.ecs
@@ -27,7 +27,7 @@ COPY --chown=redash client /frontend/client
 COPY --chown=redash webpack.config.js /frontend/
 RUN if [ "x$skip_frontend_build" = "x" ] ; then yarn build; else mkdir -p /frontend/client/dist && touch /frontend/client/dist/multi_org.html && touch /frontend/client/dist/index.html; fi
 
-FROM python:3.7-slim-buster
+FROM python:3.7-slim-bookworm
 
 EXPOSE 5000
 
@@ -87,10 +87,6 @@ WORKDIR /app
 
 # Disable PIP Cache and Version Check
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
-ENV PIP_NO_CACHE_DIR=1
-
-# rollback pip version to avoid legacy resolver problem
-RUN pip install pip==20.2.4;
 
 # We first copy only the requirements file, to avoid rebuilding on every file change.
 COPY requirements_all_ds.txt ./

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,8 @@ passlib==1.7.1
 aniso8601==8.0.0
 blinker==1.4
 psycopg2==2.8.3
-python-dateutil==2.8.0
-pytz>=2019.3
+python-dateutil>=2.6.0
+pytz
 PyYAML==5.4
 redis==4.4.4
 requests==2.21.0

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -10,8 +10,8 @@ pymongo[tls,srv]==3.9.0
 vertica-python==0.9.5
 td-client==1.0.0
 pymssql==2.1.5
-dql==0.5.26
-dynamo3==0.4.10
+dql
+dynamo3
 boto3>=1.10.0,<1.11.0
 botocore>=1.13,<1.14.0
 sasl>=0.1.3
@@ -22,7 +22,7 @@ memsql==3.2.0
 atsd_client==3.0.5
 simple_salesforce==0.74.3
 PyAthena>=1.5.0,<=1.11.5
-pymapd==0.19.0
+pymapd
 qds-sdk>=1.9.6
 # ibm-db>=2.0.9
 pydruid==0.5.7


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

The Docker image does not build because a dependency (`databend-driver`) is not available at the version we require. By fixing this (by not downgrading the version if `pip` installed), we have to loosen other dependency specifications since the latest `pip` uses a different dependency resolver.


## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A
